### PR TITLE
feat: update angular service mapping

### DIFF
--- a/src/app/articles/articles.component.ts
+++ b/src/app/articles/articles.component.ts
@@ -10,14 +10,24 @@ import { PaginationComponent } from "./ui/pagination.component";
   selector: "app-articles",
   providers: [ArticlesService],
   template: `
-    <app-search [control]="service.filterControl" />
-    <app-list [articles]="service.filteredArticles()" />
+    <div class="search-bar">
+      <app-search [control]="service.filterControl" />
+      <button
+        class="refresh"
+        (click)="service.refresh$.next()"
+        title="Refresh and search for new entries"
+      >
+        🔄
+      </button>
+    </div>
+
+    <app-list [articles]="service.articles()" />
 
     <div class="status">
-      <p *ngIf="service.status() === 'loading'">Loading...</p>
-      <div *ngIf="service.status() === 'error'">
+      <p *ngIf="service.status() === 'LOADING'">Loading...</p>
+      <div *ngIf="service.status() === 'ERROR'">
         <p>{{ service.error() }}</p>
-        <button (click)="service.retry$.next()">Retry</button>
+        <button (click)="service.refresh$.next()">Retry</button>
       </div>
     </div>
 
@@ -40,6 +50,21 @@ import { PaginationComponent } from "./ui/pagination.component";
         flex-direction: column;
         margin-bottom: 2rem;
         align-items: center;
+      }
+
+      .search-bar {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .search-bar app-search {
+        flex-grow: 1;
+      }
+
+      .refresh {
+        font-size: 24px;
+        padding: 0.75rem;
       }
     `,
   ],

--- a/src/app/articles/data-access/articles.service.ts
+++ b/src/app/articles/data-access/articles.service.ts
@@ -1,9 +1,14 @@
-import { Injectable, computed, inject, signal } from "@angular/core";
-import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { Injectable, computed, inject } from "@angular/core";
+import { toSignal } from "@angular/core/rxjs-interop";
+import { FormControl } from "@angular/forms";
+import { BehaviorSubject, Subject, combineLatest } from "rxjs";
+import { mergeMap, startWith, switchMap } from "rxjs/operators";
+import {
+  isResponseError,
+  isResponseOk,
+} from "../../shared/data-access-utils/data-access.utils";
 import { ApiService } from "../../shared/data-access/api.service";
 import { Article } from "../../shared/interfaces/article";
-import { FormControl } from "@angular/forms";
-import { Subject, retry, startWith, switchMap } from "rxjs";
 
 export interface ArticlesState {
   articles: Article[];
@@ -17,94 +22,33 @@ export interface ArticlesState {
 export class ArticlesService {
   private apiService = inject(ApiService);
 
-  private state = signal<ArticlesState>({
-    articles: [],
-    filter: null,
-    error: null,
-    status: "loading",
-    currentPage: 1,
-  });
-
-  filterControl = new FormControl();
-
-  // selectors
-  articles = computed(() => this.state().articles);
-  filter = computed(() => this.state().filter);
-  error = computed(() => this.state().error);
-  status = computed(() => this.state().status);
-  currentPage = computed(() => this.state().currentPage);
-
-  filteredArticles = computed(() => {
-    const filter = this.filter();
-
-    return filter
-      ? this.articles().filter((article) =>
-          article.title.toLowerCase().includes(filter.toLowerCase())
-        )
-      : this.articles();
-  });
-
   // sources
-  retry$ = new Subject<void>();
-  error$ = new Subject<Error>();
-  currentPage$ = new Subject<number>();
+  readonly refresh$ = new Subject<void>();
+  readonly currentPage$ = new BehaviorSubject<number>(1);
 
-  articlesForPage$ = this.currentPage$.pipe(
-    startWith(1),
-    switchMap((page) =>
-      this.apiService.getArticlesByPage(page).pipe(
-        retry({
-          delay: (err) => {
-            this.error$.next(err);
-            return this.retry$;
-          },
-        })
+  readonly filterControl = new FormControl();
+  readonly filter$ = this.filterControl.valueChanges.pipe(startWith(""));
+
+  private readonly state = toSignal(
+    this.refresh$.pipe(
+      startWith(undefined),
+      mergeMap(() => combineLatest([this.currentPage$, this.filter$])),
+      switchMap(([page, filter]) =>
+        this.apiService.getArticlesByPageAndFilter(page, filter)
       )
-    )
+    ),
+    { requireSync: true }
   );
 
-  filter$ = this.filterControl.valueChanges;
-
-  constructor() {
-    // reducers
-    this.articlesForPage$.pipe(takeUntilDestroyed()).subscribe((articles) =>
-      this.state.update((state) => ({
-        ...state,
-        articles,
-        status: "success",
-      }))
-    );
-
-    this.currentPage$
-      .pipe(takeUntilDestroyed())
-      .subscribe((currentPage) =>
-        this.state.update((state) => ({
-          ...state,
-          currentPage,
-          status: "loading",
-          articles: [],
-        }))
-      );
-
-    this.filter$.pipe(takeUntilDestroyed()).subscribe((filter) =>
-      this.state.update((state) => ({
-        ...state,
-        filter: filter === "" ? null : filter,
-      }))
-    );
-
-    this.retry$
-      .pipe(takeUntilDestroyed())
-      .subscribe(() =>
-        this.state.update((state) => ({ ...state, status: "loading" }))
-      );
-
-    this.error$.pipe(takeUntilDestroyed()).subscribe((error) =>
-      this.state.update((state) => ({
-        ...state,
-        status: "error",
-        error: error.message,
-      }))
-    );
-  }
+  // selectors
+  readonly articles = computed(() => {
+    const state = this.state();
+    return isResponseOk(state) ? state.body : [];
+  });
+  readonly error = computed(() => {
+    const state = this.state();
+    return isResponseError(state) ? state.error : undefined;
+  });
+  readonly status = computed(() => this.state().status);
+  readonly currentPage = toSignal(this.currentPage$, { requireSync: true });
 }

--- a/src/app/shared/data-access-utils/data-access.types.ts
+++ b/src/app/shared/data-access-utils/data-access.types.ts
@@ -1,0 +1,18 @@
+export type ServerResponseLoading = {
+  status: "LOADING";
+};
+
+export type ServerResponseOk<T> = {
+  status: "OK";
+  body: T;
+};
+
+export type ServerResponseError = {
+  status: "ERROR";
+  error: Error;
+};
+
+export type ServerResponse<T> =
+  | ServerResponseLoading
+  | ServerResponseOk<T>
+  | ServerResponseError;

--- a/src/app/shared/data-access-utils/data-access.utils.ts
+++ b/src/app/shared/data-access-utils/data-access.utils.ts
@@ -1,0 +1,32 @@
+import { Observable, UnaryFunction, of, pipe } from "rxjs";
+import { catchError, map, startWith } from "rxjs/operators";
+import {
+  ServerResponse,
+  ServerResponseError,
+  ServerResponseLoading,
+  ServerResponseOk,
+} from "./data-access.types";
+
+export const mapHttpResultToServerResponse = <T>(): UnaryFunction<
+  Observable<T>,
+  Observable<ServerResponse<T>>
+> =>
+  pipe(
+    map<T, ServerResponseOk<T>>((body) => ({ status: "OK", body })),
+    catchError((error) => of<ServerResponseError>({ status: "ERROR", error })),
+    startWith<ServerResponse<T>, [ServerResponseLoading]>({
+      status: "LOADING",
+    })
+  );
+
+export const isResponseOk = <T>(
+  response: ServerResponse<T>
+): response is ServerResponseOk<T> => response.status === "OK";
+
+export const isResponseError = <T>(
+  response: ServerResponse<T>
+): response is ServerResponseError => response.status === "ERROR";
+
+export const isResponseLoading = <T>(
+  response: ServerResponse<T>
+): response is ServerResponseLoading => response.status === "LOADING";

--- a/src/app/shared/data-access/api.service.ts
+++ b/src/app/shared/data-access/api.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@angular/core";
 import { delay, of, switchMap, throwError } from "rxjs";
+import { mapHttpResultToServerResponse } from "../data-access-utils/data-access.utils";
 import { Article } from "../interfaces/article";
 
 @Injectable({
@@ -25,27 +26,35 @@ export class ApiService {
     },
   ];
 
-  articles$ = of(this.articles).pipe(delay(1000));
+  articles$ = of(this.articles)
+    .pipe(delay(1000))
+    .pipe(mapHttpResultToServerResponse());
   articlesFail$ = of(this.articles).pipe(
     delay(1000),
     switchMap(() =>
       Math.random() < 0.8
         ? throwError(() => new Error("Oops"))
         : of(this.articles)
-    )
+    ),
+    mapHttpResultToServerResponse()
   );
 
-  getArticlesByPage(page: number) {
-    const articles = this.articles.map((article) => ({
-      ...article,
-      title: `Page ${page}: ${article.title}`,
-    }));
+  getArticlesByPageAndFilter(page: number, filter: string) {
+    const articles: Article[] = this.articles
+      .filter((article) =>
+        article.title.toLowerCase().includes(filter.toLowerCase())
+      )
+      .map((article) => ({
+        ...article,
+        title: `Page ${page}: ${article.title}`,
+      }));
 
     return of(articles).pipe(
       delay(1000),
       switchMap(() =>
         Math.random() < 0.5 ? throwError(() => new Error("Oops")) : of(articles)
-      )
+      ),
+      mapHttpResultToServerResponse()
     );
   }
 }


### PR DESCRIPTION
While I was watching your last two videos:

- https://www.youtube.com/watch?v=R4Ff2bPiWh4
- https://www.youtube.com/watch?v=44_IcGPKQ_M 

I wondered if it was possible to skip the subscriptions and work out something differently. I would like to hear your opinion on that matter.

Therefore, I added an idea that simply maps all server requests into a unified result object, which will always start with a loading indicator and give me the appropriate error as soon as any error occurs.

#### Filter Changes

Further, I changed the behavior of the filter because the filtering mostly happens on the server and will resolve the result with filtered entries.

An extension would be to have the API tell us how many pages could be found for the given filter, and we would always start at `page 1` as soon as the filter changed.

#### Refreshing

The idea of refreshing in case of an error was cool to see, but I often tend to have the requirement to refresh data as it could have been updated on the server. And to give the service the possibility of doing both, I changed the refresh behavior.

#### Pagination

I did not understand why the current page needed to live in the state. Therefore, I changed that too. If you completely want to prevent the usage of `BehaviorSubject`, there is also a way to archive this via subject. But this would be far more complicated for the use case.